### PR TITLE
Fix Perl::Critic issues

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Math-Function-Interpolator
 
 {{$NEXT}}
 
+1.03      2018-10-31 13:37:21+08:00 Asia/Manila
+        - Remove List::MoreUtils and replace with simpler equivalents (pairwise, indexes)
+        - Do not use `$a` and `$b` outside `sort()`
+
 1.02      2018-10-25 12:07:53+08:00 Asia/Manila
         Remove fatalized warnings
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,7 +18,6 @@ my %WriteMakefileArgs = (
   "NAME" => "Math::Function::Interpolator",
   "PREREQ_PM" => {
     "Carp" => 0,
-    "List::MoreUtils" => 0,
     "List::Util" => 0,
     "Math::Cephes::Matrix" => 0,
     "Number::Closest::XS" => 0,
@@ -35,7 +34,7 @@ my %WriteMakefileArgs = (
     "Test::FailWarnings" => 0,
     "Test::More" => "0.94"
   },
-  "VERSION" => "1.02",
+  "VERSION" => "1.03",
   "test" => {
     "TESTS" => "t/*.t"
   }
@@ -48,7 +47,6 @@ my %FallbackPrereqs = (
   "File::Spec" => 0,
   "IO::Handle" => 0,
   "IPC::Open3" => 0,
-  "List::MoreUtils" => 0,
   "List::Util" => 0,
   "Math::Cephes::Matrix" => 0,
   "Number::Closest::XS" => 0,

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,4 @@
 requires 'Carp';
-requires 'List::MoreUtils';
 requires 'List::Util';
 requires 'Math::Cephes::Matrix';
 requires 'Number::Closest::XS';

--- a/lib/Math/Function/Interpolator.pm
+++ b/lib/Math/Function/Interpolator.pm
@@ -8,7 +8,6 @@ use Carp qw(confess);
 use Scalar::Util qw(looks_like_number);
 
 use Number::Closest::XS qw(find_closest_numbers_around);
-use List::MoreUtils qw(pairwise indexes);
 use List::Util qw(min max);
 
 use Math::Function::Interpolator::Linear;
@@ -162,7 +161,7 @@ sub closest_three_points {
 
     my ($first, $second) =
         @{find_closest_numbers_around($sought, $all_points, 2)};
-    my @indexes = indexes { $first == $_ or $second == $_ } @ap;
+    my @indexes = grep { $first == $ap[$_] or $second == $ap[$_] } 0 .. $#ap;
     my $third_index =
         (max(@indexes) < $length - 2) ? max(@indexes) + 1 : min(@indexes) - 1;
     my @sorted = sort { $a <=> $b } ($first, $second, $ap[$third_index]);

--- a/lib/Math/Function/Interpolator.pm
+++ b/lib/Math/Function/Interpolator.pm
@@ -48,7 +48,7 @@ HashRef of points for interpolations
 
 =cut
 
-our $VERSION = '1.02';
+our $VERSION = '1.03';
 
 =head1 METHODS
 

--- a/lib/Math/Function/Interpolator/Cubic.pm
+++ b/lib/Math/Function/Interpolator/Cubic.pm
@@ -9,7 +9,6 @@ use warnings;
 our @ISA = qw(Math::Function::Interpolator);
 
 use Carp qw(confess);
-use List::MoreUtils qw(pairwise indexes);
 use Number::Closest::XS qw(find_closest_numbers_around);
 use Scalar::Util qw(looks_like_number);
 
@@ -83,7 +82,7 @@ sub _spline_points {
         $y_2derivative[$i] = $y_2derivative[$i] * $y_2derivative[ $i + 1 ] + $u[$i];
     }
 
-    my %y_2derivative_combined = pairwise { $a => $b } @$Xs, @y_2derivative;
+    my %y_2derivative_combined = map { $Xs->[$_] => $y_2derivative[$_] } 0 .. $#y_2derivative;
 
     $self->{'_spline_points'} = \%y_2derivative_combined;
 

--- a/lib/Math/Function/Interpolator/Quadratic.pm
+++ b/lib/Math/Function/Interpolator/Quadratic.pm
@@ -67,9 +67,9 @@ sub quadratic {
     my $solution;
     eval { $solution = $abc->simq($y) ; 1 } or
       confess 'Insoluble matrix: ' . $_;
-    my ( $a, $b, $c ) = @$solution;
+    my ( $A, $B, $C ) = @$solution;
 
-    return ( $a * ( $x**2 ) + $b * $x + $c );
+    return ( $A * ( $x**2 ) + $B * $x + $C );
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
- Remove List::MoreUtils and replace with simpler equivalents (pairwise, indexes)
- Do not use `$a` and `$b` outside `sort()`